### PR TITLE
update JOIN command to account for 422 message

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -243,7 +243,8 @@ class Bot(threading.Thread):
       # pings we respond to directly. everything else...
       else:
 # if we get disconnected this should be true upon a reconnect attempt.. ideally
-        if self.JOINED is False and message_number == "376": # wait until we receive end of MOTD before joining
+        if self.JOINED is False and (message_number == "376" or message_number == "422"): 
+          # wait until we receive end of MOTD before joining, or until the server tells us the MOTD doesn't exist
           self.chan_list = self.conf.getChannels(self.network) 
           for c in self.chan_list:
             self.send('JOIN '+c+' \n')


### PR DESCRIPTION
On a server where the motd file isn't set, it will spit out a #422 message instead of 376. Should suffice; at least for an Unreal installation.
