### PR TITLE
Fixed error in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ python-twitter
 imgurpython
 isodate
 requests
-range_key_dict
+range-key-dict


### PR DESCRIPTION
range-key-dict was spelled with underscores instead of dashes. Just went ahead and set it correctly and it now installs properly.