### PR TITLE
Fixed schedule reload issue, trailing decimals on time print, unused time import.

### DIFF
--- a/modules/schedule.py
+++ b/modules/schedule.py
@@ -1,0 +1,53 @@
+from datetime import datetime, timezone, timedelta
+import sys
+from event import Event
+
+from pytimeparse import parse
+
+if sys.version_info > (3, 0, 0):
+  try:
+    from .basemodule import BaseModule
+  except (ImportError, SystemError):
+    from modules.basemodule import BaseModule
+else:
+  try:
+      from basemodule import BaseModule
+  except (ImportError, SystemError):
+    from modules.basemodule import BaseModule
+
+
+class Schedule(BaseModule):
+  def post_init(self):
+    sched = Event("__.schedule__")
+    sched.define(msg_definition="^\.schedule")
+    sched.subscribe(self)
+    self.help = ".schedule in <1m|5h|32s|etc> say <#channel> <phrase>"
+    self.cmd = ".schedule"
+
+    # register ourself to our new sched event
+    self.bot.register_event(sched, self)
+
+  def handle(self, event):
+    if event.msg.startswith(".schedule"):
+      try:
+        split = event.msg.split()
+        if len(split) < 6:
+          self.error(event.channel)
+          return
+        chan = split[4]
+        message = ' '.join(split[5:])
+        delay = split[2]
+        send_time = datetime.now(timezone.utc)
+        td = timedelta(seconds=parse(delay))
+        target = send_time + td
+        if not chan.startswith("#"):
+          self.say(event.channel, "invalid channel.")
+          return
+        self.bot.scheduler.schedule_task(chan, message, event.user, trigger_delay=delay, source_channel=event.channel)
+        self.say(event.channel, "registered event for channel " + chan + " at " + str(target)[:-13] + " UTC.")
+      except IndexError:
+        self.error(event.channel)
+        return
+
+  def error(self, channel):
+    self.say(channel, "u guf ur furmat")


### PR DESCRIPTION
- I removed the trailing decimals on the schedule time print to the channel. Looks a bit cleaner now. 
- I also had the issue with the reload function causing the event to trigger twice. I would load up the bot, trigger the module, and it would work as intended. I would then make a change, .reload, and then trigger again. Once I did this it would print twice. If I reload again it would print 3 times, etc. I remember the fix to it was to have the module name match the event name. Once I did this the issue was fixed. I basically just changed scheduler.py to schedule.py to match the event trigger .schedule. I also changed the class name to Schedule from Sched. Everything seems to be working as intended.